### PR TITLE
Truncate command output to not overflow 17 characters

### DIFF
--- a/vsv
+++ b/vsv
@@ -311,6 +311,7 @@ process_service() {
 	if [[ -n $pid ]]; then
 		IFS= read -d $'\0' -r prog _ < /proc/$pid/cmdline
 		prog=${prog##*/}
+		prog=${prog:0:17}
 	fi
 
 	# print service line


### PR DESCRIPTION
dhcpcd, in particular, has a very long command name `dhcpcd: [master] [ip4] [ip6]`. This simply truncates the command name at 17 characters to not push the time column out of alignment on those rows.