### PR TITLE
use install(1) instead of cp(1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ clean:
 
 .PHONY: install
 install:
-	cp vsv $(PREFIX)/bin/vsv
-	cp man/vsv.8 $(PREFIX)/share/man/man8/vsv.8
+	install -DTm755 vsv $(PREFIX)/bin/vsv
+	install -DTm644 man/vsv.8 $(PREFIX)/share/man/man8/vsv.8
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
The `install` command can install files into their destination, create directories, and set file permissions all in one command.

Running `sudo make install` failed for me because the manpage directory didn't exist. This fixes that.